### PR TITLE
Fix thread starvation issue in BulkWriter

### DIFF
--- a/src/main/java/com/azure/cosmos/samples/distributedbulk/BulkWriter.java
+++ b/src/main/java/com/azure/cosmos/samples/distributedbulk/BulkWriter.java
@@ -152,7 +152,7 @@ class BulkWriter implements AutoCloseable {
             result.name());
 
         try {
-            this.bulkWriterInputBoundedElastic.disposeGracefully();
+            this.bulkWriterInputBoundedElastic.dispose();
         } catch (Throwable t) {
             logger.info(
                 "Failed to dispose bulkWriterInputBoundedElastic of batch [{}}].",
@@ -161,7 +161,7 @@ class BulkWriter implements AutoCloseable {
         }
 
         try {
-            this.bulkWriterResponsesBoundedElastic.disposeGracefully();
+            this.bulkWriterResponsesBoundedElastic.dispose();
         } catch (Throwable t) {
             logger.info(
                 "Failed to dispose bulkWriterResponsesBoundedElastic of batch [{}}].",


### PR DESCRIPTION
`BulkWriter.close` should use `Scheduler.dispose`- not `disposeGracefully`(and when using `disposeGracefully`the returned `Mono`would need to be subscribed to and awaited/blocked.